### PR TITLE
CI: Use working Android workflow for PRs

### DIFF
--- a/.github/workflows/pr-android.yml
+++ b/.github/workflows/pr-android.yml
@@ -1,0 +1,31 @@
+name: PR Android Build
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - uses: gradle/actions/setup-gradle@v3.5.0
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Accept SDK licenses
+        run: yes | sdkmanager --licenses
+
+      - name: Install SDK
+        run: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
+      - name: Build (assembleDebug only)
+        run: gradle --no-daemon clean :app:assembleDebug


### PR DESCRIPTION
Replaces failing PR workflow with mirror of green Android APK job (Temurin JDK 17, Gradle setup, Android SDK 34). Builds with `:app:assembleDebug`.